### PR TITLE
feat: revise activated pane border color

### DIFF
--- a/themes/aquarium.json
+++ b/themes/aquarium.json
@@ -416,7 +416,7 @@
 				"border": "#1c1c26",
 				"border.variant": "#1c1c26",
 				"border.focused": "#303347",
-				"border.selected": null,
+				"border.selected": "#303347",
 				"border.transparent": null,
 				"border.disabled": null,
 				"elevated_surface.background": "#1c1c26",


### PR DESCRIPTION
The current activated pane border color uses the default color of Zed. I revised it as the same color of `border.focused` 
before: 
<img width="1566" height="1018" alt="image" src="https://github.com/user-attachments/assets/33457d75-cbea-402e-8733-8ab00b45ac0d" />
after revised:
<img width="1566" height="1018" alt="image" src="https://github.com/user-attachments/assets/812c0ed6-61e1-4d07-8156-fa36f0371abe" />
